### PR TITLE
Framework containing the guidelines to assist DRF community organize DRF BoF sessions

### DIFF
--- a/birds-of-a-feather/README.md
+++ b/birds-of-a-feather/README.md
@@ -1,0 +1,23 @@
+# Developer Relations Foundation (DRF) Birds of a Feather (BoF) Framework for Conferences
+
+This framework is designed to support interactive, community-led discussions at conferences about DRF.
+The goal is to facilitate peer-to-peer knowledge sharing and encourage broader participation in the DevRel Foundation’s working groups.
+The framework is an adaptation of a format from the [TODO Group OSPOlogy BoFs](https://github.com/todogroup/ospology/tree/main/BoF), customized for the DRF audience.
+
+## Title and Description
+
+- Format: Birds of a Feather + Roundtables
+
+- Title: DevRel Foundation Ask Me Anything Session
+
+- Abstract: The DevRel Foundation is a vendor-neutral initiative aimed at building shared understanding, resources, and best practices to elevate the professional practices of developer relations across industries.
+- In response to recent challenges, including industry layoffs and the evolving landscape of DevRel roles, the foundation has established working groups to tackle pressing issues such as metrics and reporting,
+- career support, and resource aggregation. This session offers attendees the opportunity to connect with thought leaders in the DevRel Foundation community, engage in discussions about current challenges, and
+- explore ways to get involved in shaping the future of the developer relation foundation. Key questions to explore include: What strategies can showcase the return on investment of DevRel initiatives to stakeholders?
+- What skills are becoming important in the evolving DevRel landscape, and how can professionals acquire them? How can engaging with the DevRel Foundation’s working groups enhance your career?
+
+The final output will result in a report capturing the roundtable's insights and recommendations authored by the attendees, hosted under Developer Relations' Foundation GH organization under CC-BY 4.0
+
+## Template
+
+TBD

--- a/birds-of-a-feather/README.md
+++ b/birds-of-a-feather/README.md
@@ -4,16 +4,74 @@ This framework is designed to support interactive, community-led discussions at 
 The goal is to facilitate peer-to-peer knowledge sharing and encourage broader participation in the DevRel Foundation’s working groups.
 The framework is an adaptation of a format from the [TODO Group OSPOlogy BoFs](https://github.com/todogroup/ospology/tree/main/BoF), customized for the DRF audience.
 
-## Title and Description
+# Title and Description
 
 - Format: Birds of a Feather + Roundtables
 
 - Title: DevRel Foundation Ask Me Anything Session
 
-- Abstract: The DevRel Foundation is a vendor-neutral initiative aimed at building shared understanding, resources, and best practices to elevate the professional practices of developer relations across industries. In response to recent challenges, including industry layoffs and the evolving landscape of DevRel roles, the foundation has established working groups to tackle pressing issues such as metrics and reporting, career support, and resource aggregation. This session offers attendees the opportunity to connect with thought leaders in the DevRel Foundation community, engage in discussions about current challenges, and explore ways to get involved in shaping the future of the developer relation foundation. Key questions to explore include: What strategies can showcase the return on investment of DevRel initiatives to stakeholders? What skills are becoming important in the evolving DevRel landscape, and how can professionals acquire them? How can engaging with the DevRel Foundation’s working groups enhance your career?
+- Abstract: The DevRel Foundation is a vendor-neutral initiative aimed at building shared understanding, resources, and best practices to elevate the professional practices of developer relations across industries. In response to recent challenges, including industry layoffs and the evolving landscape of DevRel roles, the foundation has established working groups to tackle pressing issues such as metrics and reporting, career support, and resource aggregation. This session offers attendees the opportunity to connect with thought leaders in the DevRel Foundation community, engage in discussions about current challenges, and explore ways to get involved in shaping the future of the developer relation foundation. Key questions to explore include: What strategies can showcase the return on investment of DevRel initiatives to stakeholders? What skills are becoming important in the evolving DevRel landscape, and how can professionals acquire them? How can engaging with the DevRel Foundation’s working groups enhance your career? The final output will result in a report capturing the roundtable's insights and recommendations authored by the attendees, hosted under Developer Relations' Foundation GH organization under CC-BY 4.0
 
-The final output will result in a report capturing the roundtable's insights and recommendations authored by the attendees, hosted under Developer Relations' Foundation GH organization under CC-BY 4.0
+# Template
+## Objectives
 
-## Template
+1. Identify current challenges and emerging trends in the field of Developer Relations (DevRel)
+2. Facilitate knowledge sharing and encourage broader participation in the DevRel Foundation’s working groups
 
-TBD
+## Actors
+
+| Role            | Description |
+|-----------------|-------------|
+| MC (Moderator)  | DRF Project Manager who introduces the session, sets the context, and guides overall flow |
+| Mentors         | Facilitators from DRF working groups and/or steering committee who lead the intro panel and support roundtable discussions |
+
+## Structure
+
+### Part 1: Opening and Context (15 Minutes)
+
+The session starts with an introductory panel where:
+
+- The DevRel Foundation MC kicks off the conversation: Explains the activity flow and utline key areas to explore during the session and provides context on the Foundation’s mission
+- Mentors introduce themselves, share their areas of expertise, and mention the working groups they are involved in
+- Use a live poll platform like [slido](https://www.slido.com/) and display a QR to collect the audience's questions and curiosities and display them during the intro panel to discuss together and inspire roundtable conversations 
+
+
+### Part 2: Move into Roundtables (5 Minutes)
+
+Assign 1-2 facilitators/mentors to drive the discussion flow. Divide attendees into 2–4 roundtable groups depending on session size
+
+Participants are split into roundtables, each identified by a color (stickers will be provided). Each table will be equipped with:
+
+- Sticky notes, pens, and a whiteboard with markers for the activity
+
+### Part 3: Framing Challenges Using “How Might We” Questions (20 Minutes)
+
+Each group drafts “How Might We” questions based on their lived experiences and shared concerns. Example prompts:
+
+- How might DRF support DevRel practitioners in consolidating and curating existing metrics, playbooks, and educational materials?
+- How might DRF serve as a neutral platform to connect fragmented DevRel communities and initiatives across industries?
+- How might DRF provide infrastructure (e.g repositories, documentation, templates) to make DevRel efforts more accessible and reusable?
+- How might DRF help validate and surface emerging DevRel practices and voices that don’t yet have industry-wide visibility?
+- How might DRF offer career support resources that complement existing mentorship or job boards?
+
+Each participant writes 1–3 sticky notes with their ideas (one per note).
+
+### Part 4: Affinity Mapping (10 Minutes)
+
+- Groups cluster related sticky notes into common themes
+- Participants vote on the top two clusters for deeper exploration
+
+### Part 5: Final Remarks (5 Minutes)
+
+Facilitators / Mentors have the task to summarize the main insights and questions raised in each group, highlighting potential areas for DRF working group collaboration or further community input.
+
+## Part 6: Virtual Follow-Up (Asynchronous)
+
+The DevRel Foundation project manager will compile session outcomes that have been previously shared by Facilitators/mentors and publish them as a community-authored summary. This includes:
+
+- A report capturing insights, themes, and recommended actions discussed during the session.
+- Knowledge Integration into DRF GitHub working group repos under CC-BY 4.0 ([DevRel Foundation GH org](https://github.com/devrelfoundation/))
+
+
+
+![Image](https://github.com/user-attachments/assets/a452308d-9cb0-4ed7-825e-796fc76fb583)

--- a/birds-of-a-feather/README.md
+++ b/birds-of-a-feather/README.md
@@ -10,11 +10,7 @@ The framework is an adaptation of a format from the [TODO Group OSPOlogy BoFs](h
 
 - Title: DevRel Foundation Ask Me Anything Session
 
-- Abstract: The DevRel Foundation is a vendor-neutral initiative aimed at building shared understanding, resources, and best practices to elevate the professional practices of developer relations across industries.
-- In response to recent challenges, including industry layoffs and the evolving landscape of DevRel roles, the foundation has established working groups to tackle pressing issues such as metrics and reporting,
-- career support, and resource aggregation. This session offers attendees the opportunity to connect with thought leaders in the DevRel Foundation community, engage in discussions about current challenges, and
-- explore ways to get involved in shaping the future of the developer relation foundation. Key questions to explore include: What strategies can showcase the return on investment of DevRel initiatives to stakeholders?
-- What skills are becoming important in the evolving DevRel landscape, and how can professionals acquire them? How can engaging with the DevRel Foundation’s working groups enhance your career?
+- Abstract: The DevRel Foundation is a vendor-neutral initiative aimed at building shared understanding, resources, and best practices to elevate the professional practices of developer relations across industries. In response to recent challenges, including industry layoffs and the evolving landscape of DevRel roles, the foundation has established working groups to tackle pressing issues such as metrics and reporting, career support, and resource aggregation. This session offers attendees the opportunity to connect with thought leaders in the DevRel Foundation community, engage in discussions about current challenges, and explore ways to get involved in shaping the future of the developer relation foundation. Key questions to explore include: What strategies can showcase the return on investment of DevRel initiatives to stakeholders? What skills are becoming important in the evolving DevRel landscape, and how can professionals acquire them? How can engaging with the DevRel Foundation’s working groups enhance your career?
 
 The final output will result in a report capturing the roundtable's insights and recommendations authored by the attendees, hosted under Developer Relations' Foundation GH organization under CC-BY 4.0
 


### PR DESCRIPTION
Initiate a folder to share basic framework containing the guidelines and documentation to help DRF community leaders host DRF BoF at conferences, in order to prepare for the upcoming DRF BoF at OSSummit Europe (accepted) and future sessions 

[Preview](https://github.com/DevRel-Foundation/wg-community-engagement-support/blob/ca1be18275bb958ce69fc32a811cb62c967f34b3/birds-of-a-feather/README.md)